### PR TITLE
feat: update timestamp type from i64 to u64

### DIFF
--- a/crates/rospeek-core/src/model.rs
+++ b/crates/rospeek-core/src/model.rs
@@ -1,9 +1,9 @@
 #[derive(Debug, Clone)]
 pub struct Topic {
-    pub id: i64,
+    pub id: u16,
     pub name: String,
     pub type_name: String,
-    pub count: i64,
+    pub count: u64,
     pub serialization_format: String,
     pub offered_qos_profiles: Option<String>,
 }
@@ -11,9 +11,9 @@ pub struct Topic {
 #[derive(Debug, Clone)]
 pub struct RawMessage {
     /// UNIX epoch nanoseconds
-    pub timestamp: i64,
+    pub timestamp: u64,
     /// Topic ID
-    pub topic_id: i64,
+    pub topic_id: u16,
     /// CDR-encoded message
     pub data: Vec<u8>,
 }

--- a/crates/rospeek-core/src/reader.rs
+++ b/crates/rospeek-core/src/reader.rs
@@ -60,8 +60,8 @@ pub fn size_gb<P: AsRef<Path>>(path: P) -> f64 {
 ///
 /// assert_eq!(ns_to_iso(1630456800000000000), "2021-09-01 00:40:00");
 /// ```
-pub fn ns_to_iso(ns: i64) -> String {
-    let secs = ns / 1_000_000_000;
+pub fn ns_to_iso(ns: u64) -> String {
+    let secs = (ns / 1_000_000_000) as i64;
     let nsecs = (ns % 1_000_000_000) as u32;
     let date = DateTime::from_timestamp(secs, nsecs).unwrap();
     date.format("%Y-%m-%d %H:%M:%S").to_string()
@@ -79,7 +79,7 @@ pub fn ns_to_iso(ns: i64) -> String {
 ///
 /// assert_eq!(to_duration_sec(1630456800000000000, 1630456860000000000), 60.0);
 /// ```
-pub fn to_duration_sec(start_ns: i64, end_ns: i64) -> f64 {
+pub fn to_duration_sec(start_ns: u64, end_ns: u64) -> f64 {
     if end_ns > start_ns {
         (end_ns - start_ns) as f64 / 1_000_000_000.0
     } else {

--- a/crates/rospeek-db3/src/reader.rs
+++ b/crates/rospeek-db3/src/reader.rs
@@ -25,8 +25,8 @@ impl BagReader for Db3Reader {
                 "SELECT COALESCE(MIN(timestamp), 0), COALESCE(MAX(timestamp), 0) FROM messages",
                 [],
                 |r| {
-                    let start_ns: i64 = r.get(0)?;
-                    let end_ns: i64 = r.get(1)?;
+                    let start_ns: u64 = r.get(0)?;
+                    let end_ns: u64 = r.get(1)?;
                     Ok((start_ns, end_ns))
                 },
             )

--- a/crates/rospeek-gui/src/backend.rs
+++ b/crates/rospeek-gui/src/backend.rs
@@ -14,7 +14,7 @@ pub trait Backend: Send + Sync {
     fn read_messages(
         &self,
         topic: &str,
-        start_ns: Option<i64>,
+        start_ns: Option<u64>,
         limit: usize,
     ) -> RosPeekResult<Vec<RawMessage>>;
 }
@@ -42,7 +42,7 @@ impl Backend for ReaderBackend {
     fn read_messages(
         &self,
         topic: &str,
-        start_ns: Option<i64>,
+        start_ns: Option<u64>,
         limit: usize,
     ) -> RosPeekResult<Vec<RawMessage>> {
         let mut messages = self.inner.lock().unwrap().read_messages(topic)?;


### PR DESCRIPTION
## What

This pull request updates the timestamp and topic ID types across the codebase from signed integers (`i64`) to unsigned integers (`u64`/`u16`). This change improves type safety and consistency for time and identifier fields, ensuring they cannot be negative and better matching their real-world usage. The update affects models, trait definitions, reader implementations, and utility functions, and touches both the core and format-specific crates.

**Core model and utility changes:**
* Changed `Topic` struct fields `id` and `count` from `i64` to `u16` and `u64`, respectively, and updated `RawMessage` fields `timestamp` and `topic_id` to `u64` and `u16` in `model.rs`.
* Updated utility functions `ns_to_iso` and `to_duration_sec` to use `u64` instead of `i64` for nanosecond timestamps in `reader.rs`. [[1]](diffhunk://#diff-6a23460e5088f3498fc83dbf593eda6a5a6aad546b2a1b01744664e8f29da95bL63-R64) [[2]](diffhunk://#diff-6a23460e5088f3498fc83dbf593eda6a5a6aad546b2a1b01744664e8f29da95bL82-R82)

**Backend and trait interface changes:**
* Changed `start_ns` argument type from `Option<i64>` to `Option<u64>` in the `Backend` trait and its implementation in `backend.rs`. [[1]](diffhunk://#diff-052110588470b3c480931e8150ae105d8b51e2fb24ad59a74ea07669bc57aa7dL17-R17) [[2]](diffhunk://#diff-052110588470b3c480931e8150ae105d8b51e2fb24ad59a74ea07669bc57aa7dL45-R45)

**Reader implementations and database handling:**
* Updated timestamp queries and variables in `Db3Reader` to use `u64` instead of `i64` in `reader.rs`.
* Changed MCAP reader logic to use `u64` for `start_ns`, `end_ns`, and message times, and updated topic ID handling to use unsigned types in `reader.rs`. [[1]](diffhunk://#diff-d18899e2df9b112671ca1a447cf686c6b5bf65e38cd5b1493eeee69fbac22631L28-R29) [[2]](diffhunk://#diff-d18899e2df9b112671ca1a447cf686c6b5bf65e38cd5b1493eeee69fbac22631L38-R38) [[3]](diffhunk://#diff-d18899e2df9b112671ca1a447cf686c6b5bf65e38cd5b1493eeee69fbac22631L83-R83) [[4]](diffhunk://#diff-d18899e2df9b112671ca1a447cf686c6b5bf65e38cd5b1493eeee69fbac22631L113-R114)

**Minor cleanup:**
* Removed unused import of `i64` in `mcap` reader.