### PR TITLE
style: resolve clippy warnings

### DIFF
--- a/crates/rospeek-cli/src/main.rs
+++ b/crates/rospeek-cli/src/main.rs
@@ -66,8 +66,7 @@ fn main() -> RosPeekResult<()> {
                 let key = topic
                     .name
                     .split("/")
-                    .filter(|s| !s.is_empty())
-                    .next()
+                    .find(|s| !s.is_empty())
                     .map(|s| format!("/{}", s))
                     .unwrap_or_else(|| "/".to_string());
                 grouped.entry(key).or_default().push(topic);

--- a/crates/rospeek-core/src/cdr.rs
+++ b/crates/rospeek-core/src/cdr.rs
@@ -262,7 +262,7 @@ impl<'a> CdrDecoder<'a> {
         if buf.last() == Some(&0) {
             buf.pop(); // null terminator (optional in ROS 2)
         }
-        String::from_utf8(buf).map_err(|e| RosPeekError::InvalidUtf8(e))
+        String::from_utf8(buf).map_err(RosPeekError::InvalidUtf8)
     }
 }
 

--- a/crates/rospeek-core/src/schema.rs
+++ b/crates/rospeek-core/src/schema.rs
@@ -71,10 +71,7 @@ impl FieldType {
     }
 
     fn is_iterable(&self) -> bool {
-        match self {
-            FieldType::Object(_) => false,
-            _ => true,
-        }
+        !matches!(self, FieldType::Object(_))
     }
 }
 

--- a/crates/rospeek-gui/src/app.rs
+++ b/crates/rospeek-gui/src/app.rs
@@ -328,7 +328,7 @@ fn dump_bytes(bytes: &[u8], max_line: usize) -> String {
         }
 
         // ascii
-        out.push_str(" ");
+        out.push(' ');
         for b in chunk {
             let c = if b.is_ascii_graphic() {
                 *b as char

--- a/crates/rospeek-gui/src/app.rs
+++ b/crates/rospeek-gui/src/app.rs
@@ -190,7 +190,7 @@ impl<B: Backend + 'static> App<B> {
             ui.monospace(to_rich_text(&format!("Topic: {}", topic)).strong());
             ui.add_space(4.0);
             egui::ScrollArea::vertical().show(ui, |ui| {
-                let mut decoder = CdrDecoder::from_schema(&schema);
+                let mut decoder = CdrDecoder::from_schema(schema);
                 for (idx, msg) in self.page.iter().enumerate() {
                     let id = ui.make_persistent_id(("msg_row", msg.topic_id, msg.timestamp, idx));
                     let header = CollapsingState::load_with_default_open(ui.ctx(), id, false)

--- a/crates/rospeek-mcap/src/reader.rs
+++ b/crates/rospeek-mcap/src/reader.rs
@@ -103,7 +103,7 @@ impl BagReader for McapReader {
     fn read_messages(&self, topic_name: &str) -> RosPeekResult<Vec<RawMessage>> {
         let stream = self.as_stream()?;
 
-        let raw_messages = stream
+        stream
             .map(|message_result| {
                 message_result
                     .map_err(|_| RosPeekError::Other("Failed to read message".to_string()))
@@ -117,8 +117,6 @@ impl BagReader for McapReader {
                 Ok(_) => None,          // Skip messages from other topics
                 Err(e) => Some(Err(e)), // Propagate errors
             })
-            .collect::<RosPeekResult<Vec<RawMessage>>>();
-
-        raw_messages
+            .collect::<RosPeekResult<Vec<RawMessage>>>()
     }
 }

--- a/crates/rospeek-mcap/src/reader.rs
+++ b/crates/rospeek-mcap/src/reader.rs
@@ -13,7 +13,7 @@ pub struct McapReader {
 }
 
 impl McapReader {
-    fn into_stream(&self) -> RosPeekResult<MessageStream<'_>> {
+    fn as_stream(&self) -> RosPeekResult<MessageStream<'_>> {
         MessageStream::new(&self.mmap)
             .map_err(|e| RosPeekError::Other(format!("Failed to create message stream: {}", e)))
     }
@@ -64,7 +64,7 @@ impl BagReader for McapReader {
     fn topics(&self) -> RosPeekResult<Vec<Topic>> {
         use std::collections::HashMap;
 
-        let stream = self.into_stream()?;
+        let stream = self.as_stream()?;
 
         let topic_map: Result<HashMap<String, Topic>, RosPeekError> = stream
             .map(|message_result| {
@@ -101,7 +101,7 @@ impl BagReader for McapReader {
     }
 
     fn read_messages(&self, topic_name: &str) -> RosPeekResult<Vec<RawMessage>> {
-        let stream = self.into_stream()?;
+        let stream = self.as_stream()?;
 
         let raw_messages = stream
             .map(|message_result| {


### PR DESCRIPTION
## What

This pull request introduces several minor improvements and code cleanups across multiple crates, focusing on simplifying logic, improving naming consistency, and minor ergonomic fixes.

### Code simplification and cleanup

* Simplified the logic in `FieldType::is_iterable` to use `matches!` for better readability in `crates/rospeek-core/src/schema.rs`.
* Replaced `.filter(...).next()` with `.find(...)` for more idiomatic Rust in topic key extraction in `crates/rospeek-cli/src/main.rs`.
* Used direct closure in error mapping for UTF-8 conversion in `CdrDecoder` for conciseness in `crates/rospeek-core/src/cdr.rs`.

### Naming consistency

* Renamed the method `into_stream` to `as_stream` in `McapReader` for clarity, and updated all usages in `crates/rospeek-mcap/src/reader.rs`. [[1]](diffhunk://#diff-d18899e2df9b112671ca1a447cf686c6b5bf65e38cd5b1493eeee69fbac22631L16-R16) [[2]](diffhunk://#diff-d18899e2df9b112671ca1a447cf686c6b5bf65e38cd5b1493eeee69fbac22631L67-R67) [[3]](diffhunk://#diff-d18899e2df9b112671ca1a447cf686c6b5bf65e38cd5b1493eeee69fbac22631L104-R106) [[4]](diffhunk://#diff-d18899e2df9b112671ca1a447cf686c6b5bf65e38cd5b1493eeee69fbac22631L120-R120)

### Minor ergonomic improvements

* Passed `schema` by value instead of reference when constructing `CdrDecoder` in GUI app for cleaner code in `crates/rospeek-gui/src/app.rs`.
* Used `push(' ')` instead of `push_str(" ")` for appending a single space in byte dumping logic in `crates/rospeek-gui/src/app.rs`.