### PR TITLE
feat: rename decode command to dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ rospeek info <BAG_FILE>
 rospeek show <BAG_FILE> -t <TOPIC_NAME>
 ```
 
-#### Decode Topic Messages into JSON
+#### Decode Topic Messages and Dump into JSON
 
 ```shell
-rospeek decode <BAG_FILE> -t <TOPIC_NAME>
+rospeek dump <BAG_FILE> -t <TOPIC_NAME>
 ```
 
 #### Spawn GUI

--- a/crates/rospeek-cli/src/main.rs
+++ b/crates/rospeek-cli/src/main.rs
@@ -30,8 +30,8 @@ enum Commands {
         count: Option<usize>,
     },
 
-    /// Decode CDR-encoded messages into JSON
-    Decode {
+    /// Decode CDR-encoded messages and dump them into JSON
+    Dump {
         #[arg(value_name = "BAGFILE", help = "Path to the [.db3, .mcap] bag file")]
         bag: PathBuf,
 
@@ -91,12 +91,12 @@ fn main() -> RosPeekResult<()> {
                 println!("[{}] t = {} ns, {} bytes", i, msg.timestamp, msg.data.len());
             }
         }
-        Commands::Decode { bag, topic } => {
+        Commands::Dump { bag, topic } => {
             println!(">> Start decoding: {}", topic);
             let reader = create_reader(bag)?;
             let results = try_decode_json(reader, &topic)?;
             println!("✨Finish decoding all messages");
-            println!(">> Start saving results as JSON");
+            println!(">> Start dumping results into JSON");
             let filename = topic.trim_start_matches('/').replace('/', ".") + ".json";
             let writer = File::create(&filename)?;
             serde_json::to_writer_pretty(writer, &results)


### PR DESCRIPTION
## What 

This pull request updates the command-line interface and documentation to rename the `decode` command to `dump`, clarifying its purpose and improving consistency between the CLI and documentation. The most important changes are:

**CLI Command Renaming:**

* Renamed the `Decode` command to `Dump` in the `Commands` enum in `crates/rospeek-cli/src/main.rs`, updating its description to "Decode CDR-encoded messages and dump them into JSON".
* Updated the main function in `crates/rospeek-cli/src/main.rs` to handle the new `Dump` command and revised related print statements to use "dump" terminology.

**Documentation Updates:**

* Changed the section title and example in `README.md` from "Decode Topic Messages into JSON" using `rospeek decode` to "Decode Topic Messages and Dump into JSON" using `rospeek dump`.