### PR TITLE
feat: add support of saving CSV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,6 +2633,7 @@ name = "rospeek-cli"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "csv",
  "rospeek-core",
  "rospeek-db3",
  "rospeek-gui",

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ rospeek info <BAG_FILE>
 rospeek show <BAG_FILE> -t <TOPIC_NAME>
 ```
 
-#### Decode Topic Messages and Dump into JSON
+#### Decode Topic Messages and Dump into JSON/CSV
 
 ```shell
-rospeek dump <BAG_FILE> -t <TOPIC_NAME>
+rospeek dump <BAG_FILE> -t <TOPIC_NAME> [-f json|csv]
 ```
 
 #### Spawn GUI

--- a/crates/rospeek-cli/Cargo.toml
+++ b/crates/rospeek-cli/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5.42", features = ["derive"] }
+csv = "1.3.1"
 rospeek-core = { version = "0.1.0", path = "../rospeek-core" }
 rospeek-db3 = { version = "0.1.0", path = "../rospeek-db3" }
 rospeek-gui = { version = "0.1.0", path = "../rospeek-gui" }

--- a/crates/rospeek-cli/src/main.rs
+++ b/crates/rospeek-cli/src/main.rs
@@ -141,8 +141,15 @@ fn main() -> RosPeekResult<()> {
 
                             let value_strings = row
                                 .values()
-                                .map(|value| serde_json::to_string(value).unwrap())
-                                .collect::<Vec<_>>();
+                                .map(|value| {
+                                    serde_json::to_string(value).map_err(|e| {
+                                        RosPeekError::Other(format!(
+                                            "Failed to serialize value to string: {}",
+                                            e
+                                        ))
+                                    })
+                                })
+                                .collect::<Result<Vec<_>, _>>()?;
 
                             csv_writer.write_record(value_strings).map_err(|e| {
                                 RosPeekError::Other(format!("Failed to write CSV row: {}", e))

--- a/crates/rospeek-core/src/cdr.rs
+++ b/crates/rospeek-core/src/cdr.rs
@@ -315,15 +315,14 @@ pub fn try_decode_csv(
     let json_values = try_decode_json(reader, topic)?;
 
     let mut columns = BTreeSet::new();
-    let mut rows = Vec::new();
-
+    let mut rows = Vec::with_capacity(json_values.len());
     for value in json_values {
         if let Value::Object(object) = value {
-            let flatten = flatten_json(&object)?;
-            columns.extend(flatten.keys().cloned());
+            let result = flatten_json(&object)?;
+            columns.extend(result.keys().cloned());
             let row = columns
                 .iter()
-                .map(|col| flatten.get(col).map(|v| v.to_string()).unwrap_or_default())
+                .map(|col| result.get(col).map(|v| v.to_string()).unwrap_or_default())
                 .collect();
             rows.push(row);
         }

--- a/crates/rospeek-core/src/lib.rs
+++ b/crates/rospeek-core/src/lib.rs
@@ -3,9 +3,11 @@ pub mod error;
 pub mod model;
 pub mod reader;
 pub mod schema;
+pub mod utility;
 
 pub use cdr::*;
 pub use error::*;
 pub use model::*;
 pub use reader::*;
 pub use schema::*;
+pub use utility::*;

--- a/crates/rospeek-core/src/utility.rs
+++ b/crates/rospeek-core/src/utility.rs
@@ -1,0 +1,260 @@
+use serde_json::{Map, Value, json};
+
+use crate::RosPeekResult;
+
+pub fn json_values_to_string(json: &Vec<Value>) -> String {
+    serde_json::to_string_pretty(json).unwrap()
+}
+
+pub fn flatten_json(json: &Map<String, Value>) -> RosPeekResult<Map<String, Value>> {
+    let mut output = Map::new();
+    insert_object(&mut output, None, json);
+    Ok(output)
+}
+
+fn insert_object(
+    base_json: &mut Map<String, Value>,
+    base_key: Option<&str>,
+    object: &Map<String, Value>,
+) {
+    object.iter().for_each(|(key, value)| {
+        let new_key = base_key.map_or_else(|| key.clone(), |base_key| format!("{base_key}.{key}"));
+
+        if let Some(array) = value.as_array() {
+            insert_array(base_json, &new_key, array);
+        } else if let Some(object) = value.as_object() {
+            insert_object(base_json, Some(&new_key), object);
+        } else {
+            insert_value(base_json, &new_key, value);
+        }
+    });
+}
+
+fn insert_array(base_json: &mut Map<String, Value>, base_key: &str, array: &[Value]) {
+    array.iter().for_each(|value| {
+        if let Some(object) = value.as_object() {
+            insert_object(base_json, Some(base_key), object);
+        } else if let Some(sub_array) = value.as_array() {
+            insert_array(base_json, base_key, sub_array);
+        } else {
+            insert_value(base_json, base_key, value);
+        }
+    });
+}
+
+fn insert_value(base_json: &mut Map<String, Value>, key: &str, to_insert: &Value) {
+    if let Some(value) = base_json.get_mut(key) {
+        if let Some(array) = value.as_array_mut() {
+            array.push(to_insert.clone());
+        } else {
+            base_json[key] = json!([value, to_insert]);
+        }
+    } else {
+        base_json.insert(key.to_string(), json!(to_insert));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_flattening() {
+        let mut base: Value = json!({
+          "id": "287947",
+          "title": "Shazam!",
+          "release_date": 1553299200,
+          "genres": [
+            "Action",
+            "Comedy",
+            "Fantasy"
+          ]
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten_json(&json).unwrap_or_else(|_| panic!("Failed to flatten json"));
+
+        println!(
+            "got:\n{}\nexpected:\n{}\n",
+            serde_json::to_string_pretty(&flat).unwrap(),
+            serde_json::to_string_pretty(&json).unwrap()
+        );
+
+        assert_eq!(flat, json);
+    }
+
+    #[test]
+    fn flatten_object() {
+        let mut base: Value = json!({
+          "a": {
+            "b": "c",
+            "d": "e",
+            "f": "g"
+          }
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten_json(&json).unwrap_or_else(|_| panic!("Failed to flatten json"));
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a.b": "c",
+                "a.d": "e",
+                "a.f": "g"
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn flatten_array() {
+        let mut base: Value = json!({
+          "a": [
+            { "b": "c" },
+            { "b": "d" },
+            { "b": "e" },
+          ]
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten_json(&json).unwrap_or_else(|_| panic!("Failed to flatten json"));
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a.b": ["c", "d", "e"],
+            })
+            .as_object()
+            .unwrap()
+        );
+
+        // here we must keep 42 in "a"
+        let mut base: Value = json!({
+          "a": [
+            42,
+            { "b": "c" },
+            { "b": "d" },
+            { "b": "e" },
+          ]
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten_json(&json).unwrap_or_else(|_| panic!("Failed to flatten json"));
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a": 42,
+                "a.b": ["c", "d", "e"],
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn collision_with_object() {
+        let mut base: Value = json!({
+          "a": {
+            "b": "c",
+          },
+          "a.b": "d",
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten_json(&json).unwrap_or_else(|_| panic!("Failed to flatten json"));
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a.b": ["c", "d"],
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn collision_with_array() {
+        let mut base: Value = json!({
+          "a": [
+            { "b": "c" },
+            { "b": "d", "c": "e" },
+            [35],
+          ],
+          "a.b": "f",
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten_json(&json).unwrap_or_else(|_| panic!("Failed to flatten json"));
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a.b": ["c", "d", "f"],
+                "a.c": "e",
+                "a": 35,
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn flatten_nested_arrays() {
+        let mut base: Value = json!({
+          "a": [
+            ["b", "c"],
+            { "d": "e" },
+            ["f", "g"],
+            [
+                { "h": "i" },
+                { "d": "j" },
+            ],
+            ["k", "l"],
+          ]
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten_json(&json).unwrap_or_else(|_| panic!("Failed to flatten json"));
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a": ["b", "c", "f", "g", "k", "l"],
+                "a.d": ["e", "j"],
+                "a.h": "i",
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn flatten_nested_arrays_and_objects() {
+        let mut base: Value = json!({
+          "a": [
+            "b",
+            ["c", "d"],
+            { "e": ["f", "g"] },
+            [
+                { "h": "i" },
+                { "e": ["j", { "z": "y" }] },
+            ],
+            ["l"],
+            "m",
+          ]
+        });
+        let json = std::mem::take(base.as_object_mut().unwrap());
+        let flat = flatten_json(&json).unwrap_or_else(|_| panic!("Failed to flatten json"));
+
+        println!("{}", serde_json::to_string_pretty(&flat).unwrap());
+
+        assert_eq!(
+            &flat,
+            json!({
+                "a": ["b", "c", "d", "l", "m"],
+                "a.e": ["f", "g", "j"],
+                "a.h": "i",
+                "a.e.z": "y",
+            })
+            .as_object()
+            .unwrap()
+        );
+    }
+}

--- a/crates/rospeek-core/src/utility.rs
+++ b/crates/rospeek-core/src/utility.rs
@@ -43,7 +43,7 @@ fn insert_value(base_json: &mut Map<String, Value>, key: &str, to_insert: &Value
         if let Some(array) = value.as_array_mut() {
             array.push(to_insert.clone());
         } else {
-            base_json[key] = json!([value, to_insert]);
+            base_json[key] = json!([value.clone(), to_insert]);
         }
     } else {
         base_json.insert(key.to_string(), json!(to_insert));

--- a/crates/rospeek-core/src/utility.rs
+++ b/crates/rospeek-core/src/utility.rs
@@ -2,10 +2,6 @@ use serde_json::{Map, Value, json};
 
 use crate::RosPeekResult;
 
-pub fn json_values_to_string(json: &Vec<Value>) -> String {
-    serde_json::to_string_pretty(json).unwrap()
-}
-
 pub fn flatten_json(json: &Map<String, Value>) -> RosPeekResult<Map<String, Value>> {
     let mut output = Map::new();
     insert_object(&mut output, None, json);


### PR DESCRIPTION
## What

This pull request adds CSV export support to the `rospeek-cli` tool, allowing users to dump ROS bag topic data not only as JSON but also as CSV. The main changes include CLI improvements, new utility functions for flattening JSON data for CSV output, and integration of the CSV writing logic. These updates make it easier to analyze ROS data with spreadsheet tools.

**CLI and Output Format Enhancements**
* Added a `format` option to the `Dump` command in `main.rs`, allowing users to specify either `json` or `csv` output via the CLI. (`Format` enum and related CLI parsing)
* Integrated CSV writing logic into the `Dump` command, including header generation and row writing using the new flattening utility.

**Utility Functions for Data Transformation**
* Introduced a new `utility.rs` module in `rospeek-core` with a robust `flatten_json` function that transforms nested JSON objects into flat key-value pairs suitable for CSV output. Includes comprehensive unit tests for edge cases.
* Re-exported the new utility functions in `lib.rs` for use throughout the project.

**Dependency Updates**
* Added the `csv` crate to `rospeek-cli/Cargo.toml` to support CSV file writing.