### PR TITLE
refactor: update code relevant to CLI

### DIFF
--- a/crates/rospeek-cli/src/main.rs
+++ b/crates/rospeek-cli/src/main.rs
@@ -102,9 +102,9 @@ fn main() -> RosPeekResult<()> {
 
             let messages = reader.read_messages(&topic)?;
             let n = count.unwrap_or(messages.len());
-            for (i, msg) in messages.iter().take(n).enumerate() {
-                println!("[{}] t = {} ns, {} bytes", i, msg.timestamp, msg.data.len());
-            }
+            messages.iter().take(n).enumerate().for_each(|(i, msg)| {
+                println!("[{}] t = {} ns, {} bytes", i, msg.timestamp, msg.data.len())
+            });
         }
         Commands::Dump { bag, topic, format } => {
             println!(">> Start decoding: {}", topic);

--- a/crates/rospeek-cli/src/main.rs
+++ b/crates/rospeek-cli/src/main.rs
@@ -65,16 +65,9 @@ fn main() -> RosPeekResult<()> {
         Commands::Info { bag } => {
             let reader = create_reader(bag)?;
 
-            let stats = reader.stats();
+            println!("{}", reader.stats());
 
-            println!("File:             {}", stats.path);
-            println!("Bag size:         {:.3} GiB", stats.size_bytes);
-            println!("Storage type:     {}", stats.storage_type);
-            println!("Duration:         {} s", stats.duration_sec);
-            println!("Start:            {}", stats.start_time);
-            println!("End:              {}", stats.end_time);
             println!("Topic Information:");
-
             // group topics by namespace
             let mut grouped: BTreeMap<String, Vec<_>> = BTreeMap::new();
             for topic in reader.topics()? {

--- a/crates/rospeek-cli/src/main.rs
+++ b/crates/rospeek-cli/src/main.rs
@@ -111,17 +111,16 @@ fn main() -> RosPeekResult<()> {
             let reader = create_reader(bag)?;
             println!("✨Finish decoding all messages");
             println!(">> Start dumping results into {:?}", format);
-            match format {
+            let filename = match format {
                 Format::Json => {
                     let filename = topic.trim_start_matches('/').replace('/', ".") + ".json";
                     let writer = File::create(&filename)?;
                     let values = try_decode_json(reader, &topic)?;
                     serde_json::to_writer_pretty(writer, &values)
                         .map_err(|_| RosPeekError::Other("Failed to write JSON".to_string()))?;
-                    println!("✨Success to save JSON to: {}", filename);
+                    filename
                 }
                 Format::Csv => {
-                    println!(">> Start dumping results into CSV");
                     let filename = topic.trim_start_matches('/').replace('/', ".") + ".csv";
                     let writer = File::create(&filename)?;
                     let mut csv_writer = csv::WriterBuilder::new().from_writer(writer);
@@ -134,9 +133,10 @@ fn main() -> RosPeekResult<()> {
                             RosPeekError::Other(format!("Failed to write CSV row: {}", e))
                         })?
                     }
-                    println!("✨Success to save CSV to: {}", filename);
+                    filename
                 }
-            }
+            };
+            println!("✨Success to save {:?} to: {}", format, filename);
         }
         Commands::App => spawn_app().map_err(|e| RosPeekError::Other(format!("{e}")))?,
     }

--- a/crates/rospeek-core/src/reader.rs
+++ b/crates/rospeek-core/src/reader.rs
@@ -28,6 +28,21 @@ pub struct BagStats {
     pub end_time: String,
 }
 
+impl Display for BagStats {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "File:             {}\nBag size:         {:.3} GiB\nStorage type:     {}\nDuration:         {} s\nStart:            {}\nEnd:              {}",
+            self.path,
+            self.size_bytes,
+            self.storage_type,
+            self.duration_sec,
+            self.start_time,
+            self.end_time
+        )
+    }
+}
+
 #[derive(Debug)]
 pub enum StorageType {
     Sqlite3,


### PR DESCRIPTION
## What

This pull request refactors how bag statistics are displayed and improves the consistency of output messages in the CLI tool. The most significant changes include moving the formatting logic for bag statistics into a `Display` implementation, streamlining message printing, and unifying the success output for file dumps.

**Output formatting improvements:**

* Added a `Display` implementation for the `BagStats` struct in `reader.rs`, centralizing and simplifying the formatting logic for bag statistics.
* Updated the `Info` command in `main.rs` to print bag statistics using the new `Display` implementation, replacing individual print statements with a single call.

**Code consistency and clarity:**

* Refactored message printing in the `Read` command to use `for_each` instead of a `for` loop for improved clarity and idiomatic Rust style.
* Unified success output for both JSON and CSV dump formats by storing the filename and printing a single success message after the file is written, improving consistency and reducing repetition. [[1]](diffhunk://#diff-21dbe9b43bc8097af3ca987eb3ba7519bbde4f5bea6f2a4c8b1bde7c35676161L137-R132) [[2]](diffhunk://#diff-21dbe9b43bc8097af3ca987eb3ba7519bbde4f5bea6f2a4c8b1bde7c35676161L105-L124)