### PR TITLE
feat: add method to read messages in specific ranges

### DIFF
--- a/crates/rospeek-core/src/reader.rs
+++ b/crates/rospeek-core/src/reader.rs
@@ -39,6 +39,49 @@ pub trait BagReader: Send {
     /// A result containing a vector of raw messages or an error.
     fn read_messages(&self, topic_name: &str) -> RosPeekResult<Vec<RawMessage>>;
 
+    /// Reads messages from the bag file within optional bounds, with optional paging.
+    ///
+    /// # Arguments
+    /// * `topic_name` - The name of the topic to read messages from.
+    /// * `start_ns` - Optional start timestamp (inclusive).
+    /// * `end_ns` - Optional end timestamp (inclusive).
+    /// * `limit` - Optional maximum number of messages to return.
+    /// * `offset` - Optional number of messages to skip after filtering.
+    ///
+    /// # Returns
+    /// A result containing a vector of raw messages or an error.
+    fn read_messages_range(
+        &self,
+        topic_name: &str,
+        start_ns: Option<u64>,
+        end_ns: Option<u64>,
+        limit: Option<usize>,
+        offset: Option<usize>,
+    ) -> RosPeekResult<Vec<RawMessage>> {
+        let mut messages = self.read_messages(topic_name)?;
+
+        if let Some(start) = start_ns {
+            messages.retain(|msg| msg.timestamp >= start);
+        }
+        if let Some(end) = end_ns {
+            messages.retain(|msg| msg.timestamp <= end);
+        }
+        if let Some(offset) = offset {
+            if offset < messages.len() {
+                messages.drain(0..offset);
+            } else {
+                messages.clear();
+            }
+        }
+        if let Some(limit) = limit
+            && messages.len() > limit
+        {
+            messages.truncate(limit);
+        }
+
+        Ok(messages)
+    }
+
     /// Reads messages from the bag file since a given timestamp.
     ///
     /// # Note
@@ -51,12 +94,7 @@ pub trait BagReader: Send {
     /// # Returns
     /// A result containing a vector of raw messages or an error.
     fn read_messages_since(&self, topic_name: &str, since: u64) -> RosPeekResult<Vec<RawMessage>> {
-        let messages = self.read_messages(topic_name)?;
-        let filtered_messages = messages
-            .into_iter()
-            .filter(|msg| msg.timestamp >= since)
-            .collect();
-        Ok(filtered_messages)
+        self.read_messages_range(topic_name, Some(since), None, None, None)
     }
 
     /// Reads messages from the bag file until a given timestamp.
@@ -71,12 +109,7 @@ pub trait BagReader: Send {
     /// # Returns
     /// A result containing a vector of raw messages or an error.
     fn read_messages_until(&self, topic_name: &str, until: u64) -> RosPeekResult<Vec<RawMessage>> {
-        let messages = self.read_messages(topic_name)?;
-        let filtered_messages = messages
-            .into_iter()
-            .filter(|msg| msg.timestamp <= until)
-            .collect();
-        Ok(filtered_messages)
+        self.read_messages_range(topic_name, None, Some(until), None, None)
     }
 
     /// Reads messages from the bag file between two timestamps.
@@ -97,12 +130,7 @@ pub trait BagReader: Send {
         since: u64,
         until: u64,
     ) -> RosPeekResult<Vec<RawMessage>> {
-        let messages = self.read_messages(topic_name)?;
-        let filtered_messages = messages
-            .into_iter()
-            .filter(|msg| msg.timestamp >= since && msg.timestamp <= until)
-            .collect();
-        Ok(filtered_messages)
+        self.read_messages_range(topic_name, Some(since), Some(until), None, None)
     }
 }
 

--- a/crates/rospeek-db3/src/reader.rs
+++ b/crates/rospeek-db3/src/reader.rs
@@ -6,7 +6,7 @@ use rospeek_core::{
     reader::{BagStats, StorageType},
     size_gb, to_duration_sec,
 };
-use rusqlite::Connection;
+use rusqlite::{Connection, params_from_iter, types::Value as SqlValue};
 
 pub struct Db3Reader {
     connection: rusqlite::Connection,
@@ -72,7 +72,18 @@ impl BagReader for Db3Reader {
     }
 
     fn read_messages(&self, topic_name: &str) -> RosPeekResult<Vec<rospeek_core::RawMessage>> {
-        let topic_id = self
+        self.read_messages_range(topic_name, None, None, None, None)
+    }
+
+    fn read_messages_range(
+        &self,
+        topic_name: &str,
+        start_ns: Option<u64>,
+        end_ns: Option<u64>,
+        limit: Option<usize>,
+        offset: Option<usize>,
+    ) -> RosPeekResult<Vec<rospeek_core::RawMessage>> {
+        let topic_id: u16 = self
             .connection
             .query_row(
                 "SELECT id FROM topics WHERE name = ?1",
@@ -81,11 +92,37 @@ impl BagReader for Db3Reader {
             )
             .map_err(|_| anyhow!("Topic not found: {topic_name}"))?;
 
-        let mut statement = self.connection.prepare(
-            "SELECT timestamp, data FROM messages WHERE topic_id = ?1 ORDER BY timestamp ASC",
-        )?;
+        let mut sql = String::from("SELECT timestamp, data FROM messages WHERE topic_id = ?");
+        let mut params: Vec<SqlValue> = vec![SqlValue::from(topic_id as i64)];
 
-        let rows = statement.query_map([topic_id], |row| {
+        if let Some(start) = start_ns {
+            sql.push_str(" AND timestamp >= ?");
+            params.push(SqlValue::from(start as i64));
+        }
+        if let Some(end) = end_ns {
+            sql.push_str(" AND timestamp <= ?");
+            params.push(SqlValue::from(end as i64));
+        }
+
+        sql.push_str(" ORDER BY timestamp ASC");
+
+        let mut has_limit = false;
+        if let Some(limit) = limit {
+            sql.push_str(" LIMIT ?");
+            params.push(SqlValue::from(limit as i64));
+            has_limit = true;
+        }
+        if let Some(offset) = offset {
+            if !has_limit {
+                sql.push_str(" LIMIT -1");
+            }
+            sql.push_str(" OFFSET ?");
+            params.push(SqlValue::from(offset as i64));
+        }
+
+        let mut statement = self.connection.prepare(&sql)?;
+
+        let rows = statement.query_map(params_from_iter(params), |row| {
             Ok(RawMessage {
                 timestamp: row.get(0)?,
                 topic_id,

--- a/crates/rospeek-gui/src/backend.rs
+++ b/crates/rospeek-gui/src/backend.rs
@@ -46,16 +46,10 @@ impl Backend for ReaderBackend {
         start_ns: Option<u64>,
         limit: usize,
     ) -> RosPeekResult<Vec<RawMessage>> {
-        let mut messages = self.inner.lock().unwrap().read_messages(topic)?;
-
-        if let Some(start) = start_ns {
-            messages.retain(|m| m.timestamp >= start);
-        }
-        if messages.len() > limit {
-            messages.truncate(limit);
-        }
-
-        Ok(messages)
+        self.inner
+            .lock()
+            .unwrap()
+            .read_messages_range(topic, start_ns, None, Some(limit), None)
     }
 }
 

--- a/crates/rospeek-mcap/src/reader.rs
+++ b/crates/rospeek-mcap/src/reader.rs
@@ -93,19 +93,63 @@ impl BagReader for McapReader {
     }
 
     fn read_messages(&self, topic_name: &str) -> RosPeekResult<Vec<RawMessage>> {
-        let stream = self.as_stream()?;
+        self.read_messages_range(topic_name, None, None, None, None)
+    }
 
-        stream
-            .into_iter()
-            .filter_map(|message_result| match message_result {
-                Ok(message) if message.channel.topic == topic_name => Some(Ok(RawMessage {
-                    timestamp: message.publish_time,
-                    topic_id: message.channel.id,
-                    data: message.data.into(),
-                })),
-                Ok(_) => None, // Skip messages from other topics
-                Err(e) => Some(Err(anyhow::Error::from(e))), // Convert McapError to anyhow::Error
-            })
-            .collect::<RosPeekResult<Vec<RawMessage>>>()
+    fn read_messages_range(
+        &self,
+        topic_name: &str,
+        start_ns: Option<u64>,
+        end_ns: Option<u64>,
+        limit: Option<usize>,
+        offset: Option<usize>,
+    ) -> RosPeekResult<Vec<RawMessage>> {
+        let stream = self.as_stream()?;
+        let mut results = Vec::new();
+        let mut skipped = 0usize;
+
+        for message_result in stream.into_iter() {
+            let message = match message_result {
+                Ok(message) => message,
+                Err(e) => return Err(anyhow::Error::from(e)),
+            };
+
+            if message.channel.topic != topic_name {
+                continue;
+            }
+
+            let ts = message.publish_time;
+            if let Some(start) = start_ns
+                && ts < start
+            {
+                continue;
+            }
+            if let Some(end) = end_ns
+                && ts > end
+            {
+                continue;
+            }
+
+            if let Some(offset) = offset
+                && skipped < offset
+            {
+                skipped += 1;
+                continue;
+            }
+
+            results.push(RawMessage {
+                timestamp: ts,
+                topic_id: message.channel.id,
+                data: message.data.into(),
+            });
+
+            if let Some(limit) = limit
+                && results.len() >= limit
+            {
+                break;
+            }
+        }
+
+        Ok(results)
     }
 }


### PR DESCRIPTION
## What

This pull request introduces a new `read_messages_range` method to the `BagReader` trait, providing a unified and flexible way to query messages with optional time bounds, limits, and offsets. The implementation is added to both the MCAP and DB3 backends, and existing methods are refactored to use this new approach for consistency and code reuse.

**Core API Enhancements:**

* Added the `read_messages_range` method to the `BagReader` trait in `rospeek-core`, enabling message queries with optional start/end timestamps, limit, and offset. Existing methods like `read_messages_since`, `read_messages_until`, and `read_messages_between` are refactored to use this new method, reducing code duplication and improving maintainability. [[1]](diffhunk://#diff-6a23460e5088f3498fc83dbf593eda6a5a6aad546b2a1b01744664e8f29da95bR42-R84) [[2]](diffhunk://#diff-6a23460e5088f3498fc83dbf593eda6a5a6aad546b2a1b01744664e8f29da95bL54-R97) [[3]](diffhunk://#diff-6a23460e5088f3498fc83dbf593eda6a5a6aad546b2a1b01744664e8f29da95bL74-R112) [[4]](diffhunk://#diff-6a23460e5088f3498fc83dbf593eda6a5a6aad546b2a1b01744664e8f29da95bL100-R133)

**Backend Implementations:**

* Implemented `read_messages_range` for the DB3 backend (`Db3Reader`), constructing SQL queries dynamically to efficiently support time filtering, limits, and offsets. The basic `read_messages` method is updated to delegate to this new method. [[1]](diffhunk://#diff-4dfddb82784760069300c02b7974618be321c5a28a04d4c649d3e9a37d3fee38L75-R86) [[2]](diffhunk://#diff-4dfddb82784760069300c02b7974618be321c5a28a04d4c649d3e9a37d3fee38L84-R125) [[3]](diffhunk://#diff-4dfddb82784760069300c02b7974618be321c5a28a04d4c649d3e9a37d3fee38L9-R9)
* Implemented `read_messages_range` for the MCAP backend (`McapReader`), adding logic to filter messages by topic, time range, offset, and limit during iteration. The basic `read_messages` method is updated to delegate to this new method.

**Internal Refactoring:**

* Updated the GUI backend to use the new `read_messages_range` method, simplifying logic and ensuring consistent filtering and paging behavior.