### PR TITLE
feat: add paging feature to GUI

### DIFF
--- a/crates/rospeek-gui/src/app.rs
+++ b/crates/rospeek-gui/src/app.rs
@@ -8,8 +8,11 @@ use crate::backend::Backend;
 
 #[derive(Debug)]
 enum Command {
-    LoadTopic { name: String },
-    PageNext,
+    LoadTopic {
+        name: String,
+        offset: usize,
+        limit: usize,
+    },
 }
 
 #[derive(Debug)]
@@ -17,6 +20,7 @@ enum Event {
     Topics(Vec<Topic>),
     Page {
         topic: String,
+        offset: usize,
         msgs: Vec<RawMessage>,
     },
     Error(String),
@@ -36,7 +40,8 @@ pub struct App<B: Backend + 'static> {
     topic_filter: String,
     current_schema: Option<MessageSchema>,
     current_topic: Option<String>,
-    current_page: usize,
+    page_offset: usize,
+    page_size: usize,
     page: Vec<RawMessage>,
     view_mode: ViewMode,
     // backend workers
@@ -64,7 +69,8 @@ impl<B: Backend + 'static> App<B> {
             topic_filter: String::new(),
             current_schema: None,
             current_topic: None,
-            current_page: 0,
+            page_offset: 0,
+            page_size: 200,
             page: Vec::new(),
             view_mode: ViewMode::Auto,
             tx: txc,
@@ -94,19 +100,22 @@ impl<B: Backend + 'static> App<B> {
                         let _ = txe.send(Event::Topics(tmp_topics));
                         while let Ok(cmd) = rxc.recv() {
                             match cmd {
-                                Command::LoadTopic { name } => {
-                                    match bend.read_messages(&name, None, 200) {
-                                        Ok(msgs) => {
-                                            let _ = txe.send(Event::Page { topic: name, msgs });
-                                        }
-                                        Err(e) => {
-                                            let _ = txe.send(Event::Error(e.to_string()));
-                                        }
+                                Command::LoadTopic {
+                                    name,
+                                    offset,
+                                    limit,
+                                } => match bend.read_messages(&name, None, limit, Some(offset)) {
+                                    Ok(msgs) => {
+                                        let _ = txe.send(Event::Page {
+                                            topic: name,
+                                            offset,
+                                            msgs,
+                                        });
                                     }
-                                }
-                                Command::PageNext => {
-                                    // TODO: keep cursor; request next page
-                                }
+                                    Err(e) => {
+                                        let _ = txe.send(Event::Error(e.to_string()));
+                                    }
+                                },
                             }
                         }
                     });
@@ -116,7 +125,7 @@ impl<B: Backend + 'static> App<B> {
                     self.topics = topics;
                     self.current_schema = None;
                     self.current_topic = None;
-                    self.current_page = 0;
+                    self.page_offset = 0;
                     self.page.clear();
                     self.tx = txc;
                     self.rx = rxe;
@@ -127,7 +136,7 @@ impl<B: Backend + 'static> App<B> {
                     self.topics.clear();
                     self.current_schema = None;
                     self.current_topic = None;
-                    self.current_page = 0;
+                    self.page_offset = 0;
                     egui::PopupCloseBehavior::default();
                     eprintln!("Open failed: {e:?}")
                 }
@@ -145,7 +154,7 @@ impl<B: Backend + 'static> App<B> {
 
         let filter = self.topic_filter.to_lowercase();
         egui::ScrollArea::vertical().show(ui, |ui| {
-            for (i, topic) in self.topics.iter().enumerate() {
+            for topic in self.topics.iter() {
                 if !filter.is_empty() && !topic.name.to_lowercase().contains(&filter) {
                     continue;
                 }
@@ -159,9 +168,11 @@ impl<B: Backend + 'static> App<B> {
                 {
                     self.current_schema = MessageSchema::try_from(topic.type_name.as_ref()).ok();
                     self.current_topic = Some(topic.name.clone());
-                    self.current_page += i;
+                    self.page_offset = 0;
                     let _ = self.tx.send(Command::LoadTopic {
                         name: topic.name.clone(),
+                        offset: 0,
+                        limit: self.page_size,
                     });
                 }
             }
@@ -236,8 +247,15 @@ impl<B: Backend + 'static> App<B> {
             if ui.button("▶").clicked() { /* TODO(ktro2828): Implement timeline playback */ }
             if ui.button("⏸").clicked() { /* TODO(ktro2828): Implement timeline pause */ }
             if ui.button("⏹").clicked() { /* TODO(ktro2828): Implement timeline stop */ }
-            if ui.button("⏭").clicked() {
-                let _ = self.tx.send(Command::PageNext);
+            if ui.button("⏭").clicked()
+                && let Some(topic) = self.current_topic.clone()
+            {
+                let next_offset = self.page_offset + self.page_size;
+                let _ = self.tx.send(Command::LoadTopic {
+                    name: topic,
+                    offset: next_offset,
+                    limit: self.page_size,
+                });
             }
             ui.add_space(8.0);
             ui.label(to_rich_text("Timeline"));
@@ -252,8 +270,13 @@ impl<B: Backend + 'static> eframe::App for App<B> {
                 Event::Topics(ts) => {
                     self.topics = ts;
                 }
-                Event::Page { topic, msgs } => {
+                Event::Page {
+                    topic,
+                    offset,
+                    msgs,
+                } => {
                     if Some(topic.clone()) == self.current_topic {
+                        self.page_offset = offset;
                         self.page = msgs;
                     }
                 }

--- a/crates/rospeek-gui/src/backend.rs
+++ b/crates/rospeek-gui/src/backend.rs
@@ -17,6 +17,7 @@ pub trait Backend: Send + Sync {
         topic: &str,
         start_ns: Option<u64>,
         limit: usize,
+        offset: Option<usize>,
     ) -> RosPeekResult<Vec<RawMessage>>;
 }
 
@@ -45,11 +46,12 @@ impl Backend for ReaderBackend {
         topic: &str,
         start_ns: Option<u64>,
         limit: usize,
+        offset: Option<usize>,
     ) -> RosPeekResult<Vec<RawMessage>> {
         self.inner
             .lock()
             .unwrap()
-            .read_messages_range(topic, start_ns, None, Some(limit), None)
+            .read_messages_range(topic, start_ns, None, Some(limit), offset)
     }
 }
 


### PR DESCRIPTION
## What

This pull request refactors the paging mechanism for topic messages in the GUI, replacing the previous page-based approach with an offset/limit system for more flexible and reliable pagination. It updates the `Command`, `Event`, and `Backend` interfaces, and modifies the related UI and backend logic to support this change.

### Paging and Command/Event Refactor

* The `Command::LoadTopic` and `Event::Page` variants now include `offset` and `limit` fields, enabling offset-based pagination rather than relying on page numbers. The old `PageNext` command is removed. (`crates/rospeek-gui/src/app.rs`) [[1]](diffhunk://#diff-42d14cc25500d29af1c6252d12aed1ab571901851a47926bb65a62635c19b8e4L11-R23) [[2]](diffhunk://#diff-42d14cc25500d29af1c6252d12aed1ab571901851a47926bb65a62635c19b8e4L97-R118) [[3]](diffhunk://#diff-42d14cc25500d29af1c6252d12aed1ab571901851a47926bb65a62635c19b8e4L239-R258) [[4]](diffhunk://#diff-42d14cc25500d29af1c6252d12aed1ab571901851a47926bb65a62635c19b8e4L255-R279)

* The `App` struct replaces `current_page` with `page_offset` and `page_size`, and all logic is updated to use offsets for tracking and requesting pages of messages. (`crates/rospeek-gui/src/app.rs`) [[1]](diffhunk://#diff-42d14cc25500d29af1c6252d12aed1ab571901851a47926bb65a62635c19b8e4L39-R44) [[2]](diffhunk://#diff-42d14cc25500d29af1c6252d12aed1ab571901851a47926bb65a62635c19b8e4L67-R73) [[3]](diffhunk://#diff-42d14cc25500d29af1c6252d12aed1ab571901851a47926bb65a62635c19b8e4L119-R128) [[4]](diffhunk://#diff-42d14cc25500d29af1c6252d12aed1ab571901851a47926bb65a62635c19b8e4L130-R139) [[5]](diffhunk://#diff-42d14cc25500d29af1c6252d12aed1ab571901851a47926bb65a62635c19b8e4L162-R175)

### Backend Interface Updates

* The `Backend::read_messages` trait and its implementation now accept an `offset` parameter, which is passed through to the underlying message reading logic. (`crates/rospeek-gui/src/backend.rs`) [[1]](diffhunk://#diff-052110588470b3c480931e8150ae105d8b51e2fb24ad59a74ea07669bc57aa7dR20) [[2]](diffhunk://#diff-052110588470b3c480931e8150ae105d8b51e2fb24ad59a74ea07669bc57aa7dR49-R54)

### UI Improvements

* Pagination via the "next page" button now uses the offset/limit system, sending a `LoadTopic` command with the appropriate offset and limit when clicked. (`crates/rospeek-gui/src/app.rs`)

* Minor UI logic simplification: topic selection and filtering are streamlined by removing the unnecessary index variable in the topic list loop. (`crates/rospeek-gui/src/app.rs`)