### PR TITLE
refactor(cli): move subcommand to another file

### DIFF
--- a/crates/rospeek-cli/src/command.rs
+++ b/crates/rospeek-cli/src/command.rs
@@ -34,7 +34,7 @@ pub(crate) enum Command {
         offset: Option<usize>,
     },
 
-    /// Decode CDR-encoded messages and dump them into JSON
+    /// Decode CDR-encoded messages and dump them in the specified format
     Dump {
         #[arg(value_name = "BAGFILE", help = "Path to the [.db3, .mcap] bag file")]
         bag: PathBuf,

--- a/crates/rospeek-cli/src/command.rs
+++ b/crates/rospeek-cli/src/command.rs
@@ -1,0 +1,69 @@
+use std::path::PathBuf;
+
+use clap::{Subcommand, ValueEnum};
+
+/// Output file format for the dump command.
+#[derive(Debug, Clone, ValueEnum)]
+pub(crate) enum DumpFormat {
+    /// JSON format
+    Json,
+    /// CSV format
+    Csv,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum Command {
+    /// Show bag file information and list all topics in the bag file
+    Info {
+        #[arg(value_name = "BAGFILE", help = "Path to the [.db3, .mcap] bag file")]
+        bag: PathBuf,
+    },
+
+    /// Show the first N messages of a topic
+    Show {
+        #[arg(value_name = "BAGFILE", help = "Path to the [.db3, .mcap] bag file")]
+        bag: PathBuf,
+
+        #[arg(short, long, help = "Topic name to read messages (e.g. /tf)")]
+        topic: String,
+
+        #[arg(short, long, help = "Number of messages to show")]
+        count: Option<usize>,
+
+        #[arg(long, help = "Number of messages to skip after filtering")]
+        offset: Option<usize>,
+    },
+
+    /// Decode CDR-encoded messages and dump them into JSON
+    Dump {
+        #[arg(value_name = "BAGFILE", help = "Path to the [.db3, .mcap] bag file")]
+        bag: PathBuf,
+
+        #[arg(short, long, help = "Topic name to decode (e.g. /tf)")]
+        topic: String,
+
+        #[arg(
+            short,
+            long,
+            value_enum,
+            default_value = "json",
+            help = "Output format"
+        )]
+        format: DumpFormat,
+
+        #[arg(long, help = "Timestamp in nanoseconds since which to read messages")]
+        since: Option<u64>,
+
+        #[arg(long, help = "Timestamp in nanoseconds until which to read messages")]
+        until: Option<u64>,
+
+        #[arg(long, help = "Maximum number of messages to dump")]
+        limit: Option<usize>,
+
+        #[arg(long, help = "Number of messages to skip after filtering")]
+        offset: Option<usize>,
+    },
+
+    /// Spawn GUI application
+    App,
+}

--- a/crates/rospeek-cli/src/main.rs
+++ b/crates/rospeek-cli/src/main.rs
@@ -1,83 +1,24 @@
-use clap::{Parser, Subcommand, ValueEnum};
+mod command;
+
+use clap::Parser;
 use rospeek_core::{RosPeekResult, try_decode_csv, try_decode_json};
 use rospeek_gui::{create_reader, spawn_app};
-use std::{collections::BTreeMap, fs::File, path::PathBuf};
+use std::{collections::BTreeMap, fs::File};
+
+use crate::command::{Command, DumpFormat};
 
 #[derive(Parser)]
 #[command(name = "rospeek", about = "Peek into rosbag files", long_about = None)]
 struct Cli {
     #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// Show bag file information and list all topics in the bag file
-    Info {
-        #[arg(value_name = "BAGFILE", help = "Path to the [.db3, .mcap] bag file")]
-        bag: PathBuf,
-    },
-
-    /// Show the first N messages of a topic
-    Show {
-        #[arg(value_name = "BAGFILE", help = "Path to the [.db3, .mcap] bag file")]
-        bag: PathBuf,
-
-        #[arg(short, long, help = "Topic name to read messages (e.g. /tf)")]
-        topic: String,
-
-        #[arg(short, long, help = "Number of messages to show")]
-        count: Option<usize>,
-
-        #[arg(long, help = "Number of messages to skip after filtering")]
-        offset: Option<usize>,
-    },
-
-    /// Decode CDR-encoded messages and dump them into JSON
-    Dump {
-        #[arg(value_name = "BAGFILE", help = "Path to the [.db3, .mcap] bag file")]
-        bag: PathBuf,
-
-        #[arg(short, long, help = "Topic name to decode (e.g. /tf)")]
-        topic: String,
-
-        #[arg(
-            short,
-            long,
-            value_enum,
-            default_value = "json",
-            help = "Output format"
-        )]
-        format: Format,
-
-        #[arg(long, help = "Timestamp in nanoseconds since which to read messages")]
-        since: Option<u64>,
-
-        #[arg(long, help = "Timestamp in nanoseconds until which to read messages")]
-        until: Option<u64>,
-
-        #[arg(long, help = "Maximum number of messages to dump")]
-        limit: Option<usize>,
-
-        #[arg(long, help = "Number of messages to skip after filtering")]
-        offset: Option<usize>,
-    },
-
-    /// Spawn GUI application
-    App,
-}
-
-#[derive(Debug, Clone, ValueEnum)]
-enum Format {
-    Json,
-    Csv,
+    command: Command,
 }
 
 fn main() -> RosPeekResult<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Info { bag } => {
+        Command::Info { bag } => {
             let reader = create_reader(bag)?;
 
             println!("{}", reader.stats());
@@ -105,7 +46,7 @@ fn main() -> RosPeekResult<()> {
                 }
             }
         }
-        Commands::Show {
+        Command::Show {
             bag,
             topic,
             count,
@@ -118,7 +59,7 @@ fn main() -> RosPeekResult<()> {
                 println!("[{}] t = {} ns, {} bytes", i, msg.timestamp, msg.data.len())
             });
         }
-        Commands::Dump {
+        Command::Dump {
             bag,
             topic,
             format,
@@ -132,14 +73,14 @@ fn main() -> RosPeekResult<()> {
             println!("✨Finish decoding all messages");
             println!(">> Start dumping results into {format:?}");
             let filename = match format {
-                Format::Json => {
+                DumpFormat::Json => {
                     let filename = topic.trim_start_matches('/').replace('/', ".") + ".json";
                     let writer = File::create(&filename)?;
                     let values = try_decode_json(reader, &topic, since, until, limit, offset)?;
                     serde_json::to_writer_pretty(writer, &values)?;
                     filename
                 }
-                Format::Csv => {
+                DumpFormat::Csv => {
                     let filename = topic.trim_start_matches('/').replace('/', ".") + ".csv";
                     let writer = File::create(&filename)?;
                     let mut csv_writer = csv::WriterBuilder::new().from_writer(writer);
@@ -154,7 +95,7 @@ fn main() -> RosPeekResult<()> {
             };
             println!("✨Success to save {format:?} to: {filename}");
         }
-        Commands::App => spawn_app()?,
+        Command::App => spawn_app()?,
     }
 
     Ok(())

--- a/crates/rospeek-cli/src/main.rs
+++ b/crates/rospeek-cli/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> RosPeekResult<()> {
         } => {
             println!(">> Start decoding: {topic}");
             let reader = create_reader(bag)?;
-            println!("✨Finish decoding all messages");
+            println!("✨Successfully opened bag, starting to decode messages");
             println!(">> Start dumping results into {format:?}");
             let filename = match format {
                 DumpFormat::Json => {


### PR DESCRIPTION
## What

This pull request refactors the CLI command definitions for the `rospeek` tool to improve code organization and maintainability. The main change is moving all command-related enums and argument parsing logic from `main.rs` into a new dedicated module, `command.rs`. This makes the codebase cleaner and easier to extend in the future.

**Code organization improvements:**

* Introduced a new `command.rs` module containing the `Command` enum and `DumpFormat` value enum, moving all CLI command definitions and argument parsing out of `main.rs` for better separation of concerns.
* Updated `main.rs` to use the new `Command` and `DumpFormat` types from the `command` module, replacing the previous inline `Commands` and `Format` enums.

**Code usage updates:**

* Refactored all match arms in `main.rs` to use the new `Command` variants instead of the old `Commands` variants, ensuring consistent command handling with the new structure. [[1]](diffhunk://#diff-21dbe9b43bc8097af3ca987eb3ba7519bbde4f5bea6f2a4c8b1bde7c35676161L108-R49) [[2]](diffhunk://#diff-21dbe9b43bc8097af3ca987eb3ba7519bbde4f5bea6f2a4c8b1bde7c35676161L121-R62) [[3]](diffhunk://#diff-21dbe9b43bc8097af3ca987eb3ba7519bbde4f5bea6f2a4c8b1bde7c35676161L157-R98)
* Updated output format handling in the `Dump` command to use the new `DumpFormat` enum instead of the previous `Format` enum, clarifying intent and improving type safety.